### PR TITLE
Do not allow headless task execution when android app is in foreground

### DIFF
--- a/android/src/main/java/com/jamesisaac/rnbackgroundtask/BackgroundTaskModule.java
+++ b/android/src/main/java/com/jamesisaac/rnbackgroundtask/BackgroundTaskModule.java
@@ -1,5 +1,7 @@
 package com.jamesisaac.rnbackgroundtask;
 
+import android.app.ActivityManager;
+import android.content.Context;
 import android.util.Log;
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobRequest;
@@ -11,6 +13,8 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.Set;
 
@@ -146,5 +150,27 @@ public class BackgroundTaskModule extends ReactContextBaseJavaModule
         if (mJobRequest != null) {
             mJobRequest.schedule();
         }
+    }
+
+    public static boolean isAppOnForeground(Context context) {
+        /**
+         We need to check if app is in foreground otherwise the app will crash.
+         http://stackoverflow.com/questions/8489993/check-android-application-is-in-foreground-or-not
+         **/
+        ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> appProcesses =
+                activityManager.getRunningAppProcesses();
+        if (appProcesses == null) {
+            return false;
+        }
+        final String packageName = context.getPackageName();
+        for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
+            if (appProcess.importance ==
+                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
+                    appProcess.processName.equals(packageName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/android/src/main/java/com/jamesisaac/rnbackgroundtask/RNJob.java
+++ b/android/src/main/java/com/jamesisaac/rnbackgroundtask/RNJob.java
@@ -30,12 +30,14 @@ public class RNJob extends Job {
         headlessExtras.putInt("timeout", requestExtras.getInt("timeout", 30));
 
         Context context = getContext().getApplicationContext();
-        Intent service = new Intent(context, HeadlessTaskService.class);
-        service.putExtras(headlessExtras);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            context.startForegroundService(service);
-        } else {
-            context.startService(service);
+        if (!BackgroundTaskModule.isAppOnForeground(context)) {
+            Intent service = new Intent(context, HeadlessTaskService.class);
+            service.putExtras(headlessExtras);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(service);
+            } else {
+                context.startService(service);
+            }
         }
 
         return Result.SUCCESS;


### PR DESCRIPTION
Documentation :
https://facebook.github.io/react-native/docs/headless-js-android

[fix/crash-in-foreground]